### PR TITLE
cmd/mtgmemo: add b64 flag for encoding, and make it compatible url/std base64 format in decoding

### DIFF
--- a/cmd/mtgmemo/main_test.go
+++ b/cmd/mtgmemo/main_test.go
@@ -1,33 +1,37 @@
 package main
 
 import (
+	"strconv"
 	"testing"
 )
 
 func TestDecode(t *testing.T) {
 	cases := []struct {
-		input, want string
+		input       []string
+		want        string
 		omitMmsig   bool
 		paramsTypes string
 	}{
 		{
-			input:     `AQEByM06Awa3RMCs/e0J1uBvFQAB`,
+			input:     []string{`AQEByM06Awa3RMCs_e0J1uBvFQAB`, `AQEByM06Awa3RMCs/e0J1uBvFQAB`},
 			omitMmsig: true,
 			want:      `{"version":1,"protocol_id":1,"follow_id":"c8cd3a03-06b7-44c0-acfd-ed09d6e06f15","action":1}`,
 		},
 		{
-			input:       "AQEBecIa9NuuSuqFjx6vl4I8swADAQAIrowoFSlDh7MN7WVBRYfkAAAAAAJPkCcG",
+			input: []string{
+				"AQEBecIa9NuuSuqFjx6vl4I8swADAQAIrowoFSlDh7MN7WVBRYfkAAAAAAJPkCcG",
+			},
 			paramsTypes: `["uuid","string","decimal"]`,
 			want:        `{"version":1,"protocol_id":1,"follow_id":"79c21af4-dbae-4aea-858f-1eaf97823cb3","action":3,"mmsig":{"version":1,"members":[],"threshold":0},"params":["uuid:08ae8c28-1529-4387-b30d-ed65414587e4","string:","decimal:99.2478183"]}`,
 		},
 		{
-			input:       "AQQBs7TAnCQhQey41L3t+71YsQABAAAAAQE=",
+			input:       []string{"AQQBs7TAnCQhQey41L3t-71YsQABAAAAAQE=", "AQQBs7TAnCQhQey41L3t+71YsQABAAAAAQE="},
 			paramsTypes: `["int32","uint8"]`,
 			omitMmsig:   true,
 			want:        `{"version":1,"protocol_id":4,"follow_id":"b3b4c09c-2421-41ec-b8d4-bdedfbbd58b1","action":1,"params":["int32:1","uint8:1"]}`,
 		},
 		{
-			input:       "AQQBs7TAnCQhQey41L3t+71YsQACAAAAAQExAQ==",
+			input:       []string{"AQQBs7TAnCQhQey41L3t-71YsQACAAAAAQExAQ==", "AQQBs7TAnCQhQey41L3t+71YsQACAAAAAQExAQ=="},
 			paramsTypes: `["int32","string","uint8"]`,
 			omitMmsig:   true,
 			want:        `{"version":1,"protocol_id":4,"follow_id":"b3b4c09c-2421-41ec-b8d4-bdedfbbd58b1","action":2,"params":["int32:1","string:1","uint8:1"]}`,
@@ -35,68 +39,110 @@ func TestDecode(t *testing.T) {
 
 		// with checksum
 		{
-			input:       "AgQBs7TAnCQhQey41L3t+71YsQABAAAAAQE9SmiZ",
+			input:       []string{"AgQBs7TAnCQhQey41L3t-71YsQABAAAAAQE9SmiZ", "AgQBs7TAnCQhQey41L3t+71YsQABAAAAAQE9SmiZ"},
 			paramsTypes: `["int32","uint8"]`,
 			omitMmsig:   true,
 			want:        `{"version":2,"protocol_id":4,"follow_id":"b3b4c09c-2421-41ec-b8d4-bdedfbbd58b1","action":1,"params":["int32:1","uint8:1"]}`,
 		},
 		{
-			input:       "AgQBs7TAnCQhQey41L3t+71YsQACAAAAAQExAV5Gv0A=",
+			input:       []string{"AgQBs7TAnCQhQey41L3t-71YsQACAAAAAQExAV5Gv0A=", "AgQBs7TAnCQhQey41L3t+71YsQACAAAAAQExAV5Gv0A="},
 			paramsTypes: `["int32","string","uint8"]`,
 			omitMmsig:   true,
 			want:        `{"version":2,"protocol_id":4,"follow_id":"b3b4c09c-2421-41ec-b8d4-bdedfbbd58b1","action":2,"params":["int32:1","string:1","uint8:1"]}`,
 		},
 	}
 
-	for _, c := range cases {
-		t.Run(c.input, func(t *testing.T) {
-			got, err := Decode(c.input, c.omitMmsig, c.paramsTypes)
-			if err != nil {
-				t.Error(err)
-			}
-			if got != c.want {
-				t.Errorf("Decode(%q) == %q, want %q", c.input, got, c.want)
+	for i, c := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			for _, str := range c.input {
+				got, err := Decode(str, c.omitMmsig, c.paramsTypes)
+				if err != nil {
+					t.Error(err)
+				}
+				if got != c.want {
+					t.Errorf("Decode(%q) == %q, want %q", c.input, got, c.want)
+				}
 			}
 		})
 	}
-
 }
 
 func TestEncode(t *testing.T) {
 	cases := []struct {
 		input, want string
+		b64Method   string
 	}{
 		{
-			input: `{"version":1,"protocol_id":1,"follow_id":"c8cd3a03-06b7-44c0-acfd-ed09d6e06f15","action":1}`,
-			want:  "AQEByM06Awa3RMCs/e0J1uBvFQAB",
+			input:     `{"version":1,"protocol_id":1,"follow_id":"c8cd3a03-06b7-44c0-acfd-ed09d6e06f15","action":1}`,
+			b64Method: "url",
+			want:      "AQEByM06Awa3RMCs_e0J1uBvFQAB",
 		},
 		{
-			input: `{"version":1,"protocol_id":1,"follow_id":"79c21af4-dbae-4aea-858f-1eaf97823cb3","action":3,"mmsig":{"version":1,"members":[],"threshold":0},"params":["uuid:08ae8c28-1529-4387-b30d-ed65414587e4","string:","decimal:99.2478183"]}`,
-			want:  "AQEBecIa9NuuSuqFjx6vl4I8swADAQAIrowoFSlDh7MN7WVBRYfkAAAAAAJPkCcG",
+			input:     `{"version":1,"protocol_id":1,"follow_id":"79c21af4-dbae-4aea-858f-1eaf97823cb3","action":3,"mmsig":{"version":1,"members":[],"threshold":0},"params":["uuid:08ae8c28-1529-4387-b30d-ed65414587e4","string:","decimal:99.2478183"]}`,
+			b64Method: "url",
+			want:      "AQEBecIa9NuuSuqFjx6vl4I8swADAQAIrowoFSlDh7MN7WVBRYfkAAAAAAJPkCcG",
 		},
 		{
-			input: `{"version":1,"protocol_id":4,"follow_id":"b3b4c09c-2421-41ec-b8d4-bdedfbbd58b1","action":1,"params":["int32:1","uint8:1"]}`,
-			want:  "AQQBs7TAnCQhQey41L3t+71YsQABAAAAAQE=",
+			input:     `{"version":1,"protocol_id":4,"follow_id":"b3b4c09c-2421-41ec-b8d4-bdedfbbd58b1","action":1,"params":["int32:1","uint8:1"]}`,
+			b64Method: "url",
+			want:      "AQQBs7TAnCQhQey41L3t-71YsQABAAAAAQE=",
 		},
 		{
-			input: `{"version":1,"protocol_id":4,"follow_id":"b3b4c09c-2421-41ec-b8d4-bdedfbbd58b1","action":2,"params":["int32:1","string:1","uint8:1"]}`,
-			want:  "AQQBs7TAnCQhQey41L3t+71YsQACAAAAAQExAQ==",
+			input:     `{"version":1,"protocol_id":4,"follow_id":"b3b4c09c-2421-41ec-b8d4-bdedfbbd58b1","action":2,"params":["int32:1","string:1","uint8:1"]}`,
+			b64Method: "url",
+			want:      "AQQBs7TAnCQhQey41L3t-71YsQACAAAAAQExAQ==",
 		},
 
 		// version 2, with checksum
 		{
-			input: `{"version":2,"protocol_id":4,"follow_id":"b3b4c09c-2421-41ec-b8d4-bdedfbbd58b1","action":1,"params":["int32:1","uint8:1"]}`,
-			want:  "AgQBs7TAnCQhQey41L3t+71YsQABAAAAAQE9SmiZ",
+			input:     `{"version":2,"protocol_id":4,"follow_id":"b3b4c09c-2421-41ec-b8d4-bdedfbbd58b1","action":1,"params":["int32:1","uint8:1"]}`,
+			b64Method: "url",
+			want:      "AgQBs7TAnCQhQey41L3t-71YsQABAAAAAQE9SmiZ",
 		},
 		{
-			input: `{"version":2,"protocol_id":4,"follow_id":"b3b4c09c-2421-41ec-b8d4-bdedfbbd58b1","action":2,"params":["int32:1","string:1","uint8:1"]}`,
-			want:  "AgQBs7TAnCQhQey41L3t+71YsQACAAAAAQExAV5Gv0A=",
+			input:     `{"version":2,"protocol_id":4,"follow_id":"b3b4c09c-2421-41ec-b8d4-bdedfbbd58b1","action":2,"params":["int32:1","string:1","uint8:1"]}`,
+			b64Method: "url",
+			want:      "AgQBs7TAnCQhQey41L3t-71YsQACAAAAAQExAV5Gv0A=",
+		},
+
+		// base64 standard
+		{
+			input:     `{"version":1,"protocol_id":1,"follow_id":"c8cd3a03-06b7-44c0-acfd-ed09d6e06f15","action":1}`,
+			b64Method: "std",
+			want:      "AQEByM06Awa3RMCs/e0J1uBvFQAB",
+		},
+		{
+			input:     `{"version":1,"protocol_id":1,"follow_id":"79c21af4-dbae-4aea-858f-1eaf97823cb3","action":3,"mmsig":{"version":1,"members":[],"threshold":0},"params":["uuid:08ae8c28-1529-4387-b30d-ed65414587e4","string:","decimal:99.2478183"]}`,
+			b64Method: "std",
+			want:      "AQEBecIa9NuuSuqFjx6vl4I8swADAQAIrowoFSlDh7MN7WVBRYfkAAAAAAJPkCcG",
+		},
+		{
+			input:     `{"version":1,"protocol_id":4,"follow_id":"b3b4c09c-2421-41ec-b8d4-bdedfbbd58b1","action":1,"params":["int32:1","uint8:1"]}`,
+			b64Method: "std",
+			want:      "AQQBs7TAnCQhQey41L3t+71YsQABAAAAAQE=",
+		},
+		{
+			input:     `{"version":1,"protocol_id":4,"follow_id":"b3b4c09c-2421-41ec-b8d4-bdedfbbd58b1","action":2,"params":["int32:1","string:1","uint8:1"]}`,
+			b64Method: "std",
+			want:      "AQQBs7TAnCQhQey41L3t+71YsQACAAAAAQExAQ==",
+		},
+
+		// version 2, with checksum
+		{
+			input:     `{"version":2,"protocol_id":4,"follow_id":"b3b4c09c-2421-41ec-b8d4-bdedfbbd58b1","action":1,"params":["int32:1","uint8:1"]}`,
+			b64Method: "std",
+			want:      "AgQBs7TAnCQhQey41L3t+71YsQABAAAAAQE9SmiZ",
+		},
+		{
+			input:     `{"version":2,"protocol_id":4,"follow_id":"b3b4c09c-2421-41ec-b8d4-bdedfbbd58b1","action":2,"params":["int32:1","string:1","uint8:1"]}`,
+			b64Method: "std",
+			want:      "AgQBs7TAnCQhQey41L3t+71YsQACAAAAAQExAV5Gv0A=",
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {
-			got, err := Encode(c.input)
+			got, err := Encode(c.input, c.b64Method)
 			if err != nil {
 				t.Error(err)
 			}


### PR DESCRIPTION
```bash
% ./mtgmemo -e '{"version":2,"protocol_id":4,"follow_id":"33c11af4-dbae-2cea-158f-2eaf97872dc8","action":1,"params":["int32:1","uint8:1"]}'
AgQBM8Ea9NuuLOoVjy6vl4ctyAABAAAAAQGaHI/0

% ./mtgmemo -e '{"version":2,"protocol_id":4,"follow_id":"33c11af4-dbae-2cea-158f-2eaf97872dc8","action":1,"params":["int32:1","uint8:1"]}' -b64 url
AgQBM8Ea9NuuLOoVjy6vl4ctyAABAAAAAQGaHI_0

% ./mtgmemo -om -d 'AgQBM8Ea9NuuLOoVjy6vl4ctyAABAAAAAQGaHI/0' -pts '["int32","uint8"]'
{"version":2,"protocol_id":4,"follow_id":"33c11af4-dbae-2cea-158f-2eaf97872dc8","action":1,"params":["int32:1","uint8:1"]}

% ./mtgmemo -om -d 'AgQBM8Ea9NuuLOoVjy6vl4ctyAABAAAAAQGaHI_0' -pts '["int32","uint8"]'
{"version":2,"protocol_id":4,"follow_id":"33c11af4-dbae-2cea-158f-2eaf97872dc8","action":1,"params":["int32:1","uint8:1"]}

```