### PR TITLE
mtgpack: implement EncodeDecimalToBytes and DecodeDecimalFromBytes 

### DIFF
--- a/mtgpack/decode.go
+++ b/mtgpack/decode.go
@@ -3,6 +3,7 @@ package mtgpack
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"time"
 
@@ -149,6 +150,29 @@ func (d *Decoder) DecodeDecimal() (decimal.Decimal, error) {
 	}
 
 	return decimal.NewFromInt(x).Shift(-fixedDecimalPrecision), nil
+}
+
+// DecodeDecimalFromBytes decodes a decimal.Decimal number from the bytes.
+func (d *Decoder) DecodeDecimalFromBytes() (decimal.Decimal, error) {
+	data, err := d.DecodeBytes()
+	if err != nil {
+		return decimal.Zero, err
+	}
+	var v int64
+	switch len(data) {
+	case 1:
+		v = int64(uint8(data[0]))
+	case 2:
+		v = int64(binary.BigEndian.Uint16(data))
+	case 4:
+		v = int64(binary.BigEndian.Uint32(data))
+	case 8:
+		v = int64(binary.BigEndian.Uint64(data))
+	default:
+		return decimal.Zero, fmt.Errorf("invalid decimal bytes length: %d", len(data))
+	}
+
+	return decimal.NewFromInt(v).Shift(-fixedDecimalPrecision), nil
 }
 
 // DecodeTime decodes a time.Time from the input.

--- a/mtgpack/decode_test.go
+++ b/mtgpack/decode_test.go
@@ -2,7 +2,10 @@ package mtgpack
 
 import (
 	"reflect"
+	"strconv"
 	"testing"
+
+	"github.com/shopspring/decimal"
 )
 
 func TestDecodeUUID(t *testing.T) {
@@ -22,4 +25,34 @@ func TestDecodeUUID(t *testing.T) {
 	}
 
 	t.Logf("len: %d", val.Len())
+}
+
+func TestDecodeDecimalFromBytes(t *testing.T) {
+	cases := []struct {
+		b   []byte
+		exp decimal.Decimal
+	}{
+		{
+			b:   []byte{1, 1},
+			exp: decimal.NewFromFloat(0.00000001),
+		},
+		{
+			b:   []byte{8, 0, 0, 0, 2, 84, 11, 228, 0},
+			exp: decimal.NewFromInt(100),
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			dec := NewDecoder(c.b)
+			d, err := dec.DecodeDecimalFromBytes()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !d.Equals(c.exp) {
+				t.Fatalf("expected %v, got %v", c.exp, d)
+			}
+		})
+	}
 }

--- a/mtgpack/encode.go
+++ b/mtgpack/encode.go
@@ -159,6 +159,31 @@ func (e *Encoder) EncodeDecimal(d decimal.Decimal) error {
 	return e.EncodeInt64(x)
 }
 
+// EncodeDecimal encodes the given decimal into the buffer. It first shifts the decimal
+// by fixedDecimalPrecision and then encodes the resulting bytes using EncodeBytes.
+func (e *Encoder) EncodeDecimalToBytes(d decimal.Decimal) error {
+	x := d.Shift(fixedDecimalPrecision).IntPart()
+	var data []byte
+	switch {
+	case x <= math.MaxUint8:
+		data = []byte{uint8(x)}
+	case x <= math.MaxUint16:
+		var b [2]byte
+		binary.BigEndian.PutUint16(b[:], uint16(x))
+		data = b[:]
+	case x <= math.MaxUint32:
+		var b [4]byte
+		binary.BigEndian.PutUint32(b[:], uint32(x))
+		data = b[:]
+	default:
+		var b [8]byte
+		binary.BigEndian.PutUint64(b[:], uint64(x))
+		data = b[:]
+	}
+
+	return e.EncodeBytes(data)
+}
+
 // EncodeBool encodes the given bool into the buffer as a single byte (1 for true, 0 for false).
 func (e *Encoder) EncodeBool(b bool) error {
 	if b {

--- a/mtgpack/encode_test.go
+++ b/mtgpack/encode_test.go
@@ -1,0 +1,38 @@
+package mtgpack
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestEncodeDecimalToBytes(t *testing.T) {
+	cases := []struct {
+		dec decimal.Decimal
+		exp []byte
+	}{
+		{
+			dec: decimal.NewFromFloat(0.00000001),
+			exp: []byte{1, 1},
+		},
+		{
+			dec: decimal.NewFromFloat(100),
+			exp: []byte{8, 0, 0, 0, 2, 84, 11, 228, 0},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.dec.String(), func(t *testing.T) {
+			enc := NewEncoder()
+			err := enc.EncodeDecimalToBytes(c.dec)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(enc.Bytes(), c.exp) {
+				t.Fatalf("expected %v, got %v", c.exp, enc.Bytes())
+			}
+		})
+	}
+}


### PR DESCRIPTION
```bash
% ./mtgmemo -e '{"version":2,"protocol_id":4,"follow_id":"33c11af4-dbae-2cea-158f-2eaf97872dc8","action":1,"params":["int32:1","decimal-bytes:1"]}'
AgQBM8Ea9NuuLOoVjy6vl4ctyAABAAAAAQQF9eEAXMbiEQ==

% ./mtgmemo -d AgQBM8Ea9NuuLOoVjy6vl4ctyAABAAAAAQQF9eEAXMbiEQ== -om -pts '["int32","decimal-bytes"]'
{"version":2,"protocol_id":4,"follow_id":"33c11af4-dbae-2cea-158f-2eaf97872dc8","action":1,"params":["int32:1","decimal-bytes:1"]}
```
An example of a comparison between `string`, `decimal` and `decimal-byte` types.
![image](https://github.com/pandodao/mtg/assets/11025519/88d451bc-2acd-4262-8c0d-16d4337e72c2)
